### PR TITLE
fix: remove blocked keepalive action and fix screenshot capture bug

### DIFF
--- a/.github/workflows/update_resume.yml
+++ b/.github/workflows/update_resume.yml
@@ -71,7 +71,3 @@ jobs:
           name: playwright-artifacts
           path: |
             error-*.png
-
-      - name: Keepalive
-        if: always()
-        uses: gautamkrishnar/keepalive-workflow@v2

--- a/src/services/jobkorea.ts
+++ b/src/services/jobkorea.ts
@@ -238,17 +238,14 @@ export class JobKoreaService {
         } catch (error) {
           const screenshotPath = `error-update-${Date.now()}.png`;
 
-          // 스크린샷 촬영을 비동기로 처리 (에러 전파 차단)
-          Promise.resolve().then(async () => {
-            try {
-              const pageToScreenshot =
-                resumePopup && !resumePopup.isClosed() ? resumePopup : this.page;
-              await pageToScreenshot.screenshot({ path: screenshotPath, fullPage: true });
-              Logger.error(`업데이트 실패. 스크린샷 저장: ${screenshotPath}`);
-            } catch (screenshotError) {
-              Logger.error("스크린샷 저장 실패", screenshotError as Error);
-            }
-          });
+          try {
+            const pageToScreenshot =
+              resumePopup && !resumePopup.isClosed() ? resumePopup : this.page;
+            await pageToScreenshot.screenshot({ path: screenshotPath, fullPage: true });
+            Logger.error(`업데이트 실패. 스크린샷 저장: ${screenshotPath}`);
+          } catch (screenshotError) {
+            Logger.error("스크린샷 저장 실패", screenshotError as Error);
+          }
 
           if (
             error instanceof UpdateError ||


### PR DESCRIPTION
- Remove gautamkrishnar/keepalive-workflow@v2 which has been blocked by
  GitHub since 2025-04-21 for TOS violation, causing all workflow runs
  to fail at "Set up job" step
- Fix fire-and-forget screenshot capture in updateCareerInfo that used
  Promise.resolve().then() without await, causing error screenshots to
  not be saved before process exit

https://claude.ai/code/session_012Vmc5Q81oR2hi3xbUVCjfz