### PR TITLE
fix: replace blocked keepalive action with liskin/gh-workflow-keepalive

### DIFF
--- a/.github/workflows/update_resume.yml
+++ b/.github/workflows/update_resume.yml
@@ -71,3 +71,11 @@ jobs:
           name: playwright-artifacts
           path: |
             error-*.png
+
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1


### PR DESCRIPTION
gautamkrishnar/keepalive-workflow@v2 was blocked by GitHub for TOS violation. Use liskin/gh-workflow-keepalive@v1 which re-enables the workflow via GitHub API without creating dummy commits.

https://claude.ai/code/session_012Vmc5Q81oR2hi3xbUVCjfz