### PR TITLE
Improve login navigation diagnostics

### DIFF
--- a/src/services/browser.ts
+++ b/src/services/browser.ts
@@ -7,6 +7,39 @@ export class BrowserService {
   private context: BrowserContext | null = null;
   private page: Page | null = null;
 
+  private wirePageDiagnostics(page: Page): void {
+    page.on("domcontentloaded", () => {
+      Logger.info("메인 페이지 DOMContentLoaded", { url: page.url() }, "navigation");
+    });
+
+    page.on("load", () => {
+      Logger.info("메인 페이지 load 완료", { url: page.url() }, "navigation");
+    });
+
+    page.on("framenavigated", (frame) => {
+      if (frame === page.mainFrame()) {
+        Logger.info("메인 프레임 URL 변경", { url: frame.url() }, "navigation");
+      }
+    });
+
+    page.on("requestfailed", (request) => {
+      if (!request.isNavigationRequest()) {
+        return;
+      }
+
+      Logger.warning(
+        "네비게이션 요청 실패",
+        {
+          url: request.url(),
+          resourceType: request.resourceType(),
+          method: request.method(),
+          failure: request.failure()?.errorText,
+        },
+        "navigation"
+      );
+    });
+  }
+
   async initialize(): Promise<void> {
     try {
       const browserConfig = configManager.getBrowserConfig();
@@ -76,6 +109,9 @@ export class BrowserService {
       }
 
       this.page = await this.context.newPage();
+      this.page.setDefaultNavigationTimeout(configManager.getTimeouts().navigation);
+      this.page.setDefaultTimeout(configManager.getTimeouts().element);
+      this.wirePageDiagnostics(this.page);
 
       Logger.info("브라우저 초기화 완료 (최적화 적용)");
     } catch (error) {

--- a/src/services/jobkorea.ts
+++ b/src/services/jobkorea.ts
@@ -42,16 +42,48 @@ export class JobKoreaService {
   async navigateToLoginPage(): Promise<void> {
     await withRetry(
       async () => {
-        await this.page.goto(this.urls.login, {
-          waitUntil: "domcontentloaded",
+        const response = await this.page.goto(this.urls.login, {
+          waitUntil: "commit",
           timeout: this.timeouts.navigation,
         });
 
+        Logger.info(
+          "로그인 페이지 최초 응답 수신",
+          {
+            requestedUrl: this.urls.login,
+            currentUrl: this.page.url(),
+            responseUrl: response?.url() ?? null,
+            status: response?.status() ?? null,
+            ok: response?.ok() ?? null,
+          },
+          "navigation"
+        );
+
+        try {
+          await this.page.waitForLoadState("domcontentloaded", {
+            timeout: Math.floor(this.timeouts.navigation / 2),
+          });
+        } catch (error) {
+          Logger.warning(
+            "DOMContentLoaded 대기 시간 초과. 셀렉터 기준으로 계속 진행합니다.",
+            {
+              currentUrl: this.page.url(),
+              reason: error instanceof Error ? error.message : String(error),
+            },
+            "navigation"
+          );
+        }
+
         await this.waitForAnySelector(this.selectors.login.idInput, {
           state: "visible",
+          timeout: this.timeouts.navigation,
         });
 
-        Logger.success("로그인 페이지로 성공적으로 이동 및 확인 완료");
+        Logger.success(
+          "로그인 페이지로 성공적으로 이동 및 확인 완료",
+          { currentUrl: this.page.url() },
+          "navigation"
+        );
       },
       {
         maxRetries: this.retryConfig.maxOperationRetries,
@@ -78,7 +110,11 @@ export class JobKoreaService {
       }
 
       throw new NavigationError(
-        `로그인 페이지로 이동하는데 실패했습니다. (${this.retryConfig.maxOperationRetries}번 재시도): ${originalError.message}`
+        `로그인 페이지로 이동하는데 실패했습니다. (${this.retryConfig.maxOperationRetries}번 재시도): ${originalError.message}`,
+        {
+          requestedUrl: this.urls.login,
+          currentUrl: this.page.url(),
+        }
       );
     });
   }

--- a/src/services/jobkorea.ts
+++ b/src/services/jobkorea.ts
@@ -23,6 +23,22 @@ export class JobKoreaService {
     const { state = "visible" } = options;
     const timeout = options.timeout || this.timeouts.element;
 
+    if (state === "visible") {
+      await this.page.waitForSelector(selectors.join(", "), {
+        state,
+        timeout,
+      });
+
+      for (const selector of selectors) {
+        if (await this.page.locator(selector).first().isVisible()) {
+          Logger.info(`셀렉터 성공: ${selector}`);
+          return selector;
+        }
+      }
+
+      throw new Error(`표시된 셀렉터를 찾지 못했습니다: ${selectors.join(", ")}`);
+    }
+
     for (const selector of selectors) {
       try {
         await this.page.waitForSelector(selector, {


### PR DESCRIPTION
## Summary
- relax login-page navigation from a strict `domcontentloaded` gate to an earlier commit-based transition
- continue login-page verification via selector detection even when `DOMContentLoaded` is slow
- add main-frame navigation diagnostics to clarify future GitHub Actions failures

## Verification
- `pnpm lint`
- `pnpm build`
- manual workflow run succeeded: https://github.com/nanggo/jobkroea-updater/actions/runs/24628267203
