### PR TITLE
Upgrade GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
+        with:
+          version: 10.30.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/update_resume.yml
+++ b/.github/workflows/update_resume.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
+        with:
+          version: 10.30.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/update_resume.yml
+++ b/.github/workflows/update_resume.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "pnpm"
@@ -38,7 +38,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright/
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload Playwright Artifacts on Failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-artifacts
           path: |


### PR DESCRIPTION
## Summary
- upgrade workflow action versions to Node 24 runtime-compatible releases
- keep the project runtime on Node 24 while removing deprecated Node 20 action runtimes
- pin `pnpm/action-setup` to `10.30.3` to keep lockfile parsing aligned with the repo

## Verification
- manual workflow run succeeded: https://github.com/nanggo/jobkroea-updater/actions/runs/24628804499
