### PR TITLE
[codex] Add auto rerun for JobKorea probe failures

### DIFF
--- a/.github/workflows/auto_rerun_update_resume.yml
+++ b/.github/workflows/auto_rerun_update_resume.yml
@@ -1,0 +1,58 @@
+# .github/workflows/auto_rerun_update_resume.yml
+name: Auto Rerun Update Resume
+
+on:
+  workflow_run:
+    workflows: ["Update Resume"]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: auto-rerun-update-resume-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  rerun-on-probe-failure:
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt == 1
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check probe failure
+        id: probe-failure
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+
+          failed_probe_notifications="$(gh run view "${RUN_ID}" --repo "${GH_REPO}" --json jobs --jq '
+            [.jobs[]
+              | select(.name == "update-resume")
+              | .steps[]
+              | select(.name == "Notify JobKorea probe failure" and .conclusion == "failure")
+            ] | length
+          ')"
+
+          if [ "${failed_probe_notifications}" = "1" ]; then
+            echo "should_rerun=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "should_rerun=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Rerun failed update job
+        if: steps.probe-failure.outputs.should_rerun == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: gh run rerun "${RUN_ID}" --repo "${GH_REPO}" --failed
+
+      - name: Skip non-probe failure
+        if: steps.probe-failure.outputs.should_rerun != 'true'
+        run: echo "Failure was not caused by the JobKorea probe; skipping auto rerun."

--- a/.github/workflows/update_resume.yml
+++ b/.github/workflows/update_resume.yml
@@ -76,15 +76,29 @@ jobs:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
-          MESSAGE="$(cat <<EOF
-          ❌ 이력서 업데이트 최종 실패!
+          if [ "${RUN_ATTEMPT}" = "1" ]; then
+            MESSAGE="$(cat <<EOF
+          ⚠️ 이력서 업데이트 일시 실패
           이유: GitHub Actions runner에서 JobKorea 로그인 페이지에 연결할 수 없습니다.
+          조치: 새 runner로 자동 재시도 예정입니다. (최대 1회)
           대상: https://www.jobkorea.co.kr/Login/
           확인: ${RUN_URL}
           시간: $(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M:%S KST')
           EOF
           )"
+          else
+            MESSAGE="$(cat <<EOF
+          ❌ 이력서 업데이트 최종 실패!
+          이유: GitHub Actions runner에서 JobKorea 로그인 페이지에 연결할 수 없습니다.
+          재시도: 자동 재시도 후에도 연결 실패
+          대상: https://www.jobkorea.co.kr/Login/
+          확인: ${RUN_URL}
+          시간: $(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M:%S KST')
+          EOF
+          )"
+          fi
 
           curl --silent --show-error --fail \
             --request POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# Local Playwright tooling
+.playwright-cli/
+.playwright-mcp/
+
 # OS files
 .DS_Store
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ TELEGRAM_CHAT_ID=
 
 GitHub Actions에서는 JobKorea 접속 지연을 견디기 위해 아래 선택 환경변수를 사용할 수 있습니다.
 
+JobKorea 로그인 페이지 probe가 GitHub Actions runner 네트워크 문제로 실패하면, 첫 실패 알림은 "자동 재시도 예정"으로 전송하고 failed job을 새 runner로 1회 자동 재실행합니다. 재실행에서도 probe가 실패하면 최종 실패 알림을 보냅니다.
+
 ```
 NAVIGATION_TIMEOUT_MS=
 ELEMENT_TIMEOUT_MS=


### PR DESCRIPTION
## What changed
- Added an `Auto Rerun Update Resume` workflow that listens for completed `Update Resume` runs.
- When the first attempt fails specifically through the JobKorea probe failure path, it reruns only the failed jobs once with `gh run rerun --failed`.
- Updated the probe failure Telegram message so the first attempt says an automatic retry is expected, while later attempts still send a final failure message.
- Documented the retry behavior in the README.

## Why
Recent failures show GitHub-hosted runners intermittently cannot connect to `www.jobkorea.co.kr:443`, while rerunning the same workflow can succeed immediately on a different runner/IP.

## Impact
Probe-only network failures get one automatic rerun instead of requiring a manual rerun. Non-probe failures are not automatically retried.

## Checks
- `pnpm tsc --noEmit`
- `git diff --check`
- YAML parse check for both workflow files
- `bash -n` check for workflow `run` blocks