### PR TITLE
Harden update resume retries

### DIFF
--- a/.github/workflows/auto_rerun_update_resume.yml
+++ b/.github/workflows/auto_rerun_update_resume.yml
@@ -15,18 +15,17 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  rerun-on-dispatch-failure:
+  recover-dispatch-failure:
     if: >
       (github.event.workflow_run.event == 'schedule' ||
       github.event.workflow_run.event == 'workflow_dispatch') &&
-      github.event.workflow_run.conclusion == 'failure' &&
-      github.event.workflow_run.run_attempt <= 4
+      github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
       - name: Check retry dispatch failure
-        id: dispatch-failure
+        id: dispatch_failure
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -34,7 +33,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          retry_job_id="$(timeout 30s gh run view "${RUN_ID}" --repo "${GH_REPO}" --json jobs --jq '
+          retry_job_name="$(timeout 30s gh run view "${RUN_ID}" --repo "${GH_REPO}" --json jobs --jq '
             [.jobs[] as $job
               | $job.steps[]?
               | select(
@@ -42,58 +41,68 @@ jobs:
                    .name == "Dispatch retry after update failure") and
                   .conclusion == "failure"
                 )
-              | $job.databaseId
+              | $job.name
             ] | .[0] // empty
           ')"
 
-          if [ -n "${retry_job_id}" ]; then
-            echo "should_rerun=true" >> "${GITHUB_OUTPUT}"
-            echo "retry_job_id=${retry_job_id}" >> "${GITHUB_OUTPUT}"
-          else
-            echo "should_rerun=false" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Rerun failed retry dispatcher
-        if: >
-          steps.dispatch-failure.outputs.should_rerun == 'true' &&
-          github.event.workflow_run.run_attempt < 4
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
-          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
-          RETRY_JOB_ID: ${{ steps.dispatch-failure.outputs.retry_job_id }}
-        run: |
-          set -euo pipefail
-
-          case "${RUN_ATTEMPT}" in
-            1)
-              delay_seconds=180
-              ;;
-            2)
-              delay_seconds=480
-              ;;
-            3)
-              delay_seconds=900
+          case "${retry_job_name}" in
+            update-resume-probe-[1-4]|retry-update-resume-[1-4])
+              source_attempt="${retry_job_name##*-}"
               ;;
             *)
-              delay_seconds=0
+              echo "should_dispatch=false" >> "${GITHUB_OUTPUT}"
+              exit 0
               ;;
           esac
 
-          if [ "${delay_seconds}" -gt 0 ]; then
-            echo "Waiting ${delay_seconds}s before rerunning failed retry dispatcher."
-            sleep "${delay_seconds}"
+          if [ "${source_attempt}" -lt 4 ]; then
+            echo "should_dispatch=true" >> "${GITHUB_OUTPUT}"
+            echo "source_attempt=${source_attempt}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "should_dispatch=false" >> "${GITHUB_OUTPUT}"
           fi
 
-          timeout 30s gh run rerun "${RUN_ID}" \
-            --repo "${GH_REPO}" \
-            --job "${RETRY_JOB_ID}"
+      - name: Dispatch missed retry
+        id: dispatch_missed_retry
+        if: steps.dispatch_failure.outputs.should_dispatch == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RETRY_REF: ${{ github.event.workflow_run.head_branch }}
+          SOURCE_ATTEMPT: ${{ steps.dispatch_failure.outputs.source_attempt }}
+        run: |
+          set -euo pipefail
+
+          NEXT_ATTEMPT=$((SOURCE_ATTEMPT + 1))
+          RETRY_REF="${RETRY_REF:-main}"
+          echo "Waiting 180s before recovering retry attempt ${NEXT_ATTEMPT}/4."
+          sleep 180
+
+          dispatch_retry() {
+            local dispatch_attempt dispatch_delay
+            for dispatch_attempt in 1 2 3; do
+              if timeout 30s gh workflow run update_resume.yml \
+                --repo "${GH_REPO}" \
+                --ref "${RETRY_REF}" \
+                -f "attempt=${NEXT_ATTEMPT}"; then
+                return 0
+              fi
+
+              if [ "${dispatch_attempt}" -lt 3 ]; then
+                dispatch_delay=$((dispatch_attempt * 5))
+                echo "Fallback dispatch failed (${dispatch_attempt}/3). Retrying in ${dispatch_delay}s."
+                sleep "${dispatch_delay}"
+              fi
+            done
+            return 1
+          }
+
+          dispatch_retry
 
       - name: Notify exhausted dispatch fallback
         if: >
-          steps.dispatch-failure.outputs.should_rerun == 'true' &&
-          github.event.workflow_run.run_attempt >= 4
+          failure() &&
+          steps.dispatch_missed_retry.outcome == 'failure'
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
@@ -103,8 +112,8 @@ jobs:
 
           MESSAGE="$(cat <<EOF
           ❌ 이력서 업데이트 재시도 생성 실패
-          이유: 실패 후 다음 workflow run을 생성하지 못했습니다.
-          조치: 자동 보조 재실행도 모두 소진되었습니다.
+          이유: 기본 요청과 보조 요청 모두 다음 workflow run을 생성하지 못했습니다.
+          조치: GitHub Actions에서 수동 재실행이 필요합니다.
           확인: ${RUN_URL}
           시간: $(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M:%S KST')
           EOF
@@ -119,5 +128,5 @@ jobs:
             --data-urlencode "text=${MESSAGE}" || echo "Telegram fallback exhaustion notification failed"
 
       - name: Skip non-dispatch failure
-        if: steps.dispatch-failure.outputs.should_rerun != 'true'
-        run: echo "Failure was not caused by a retry dispatch error; skipping fallback rerun."
+        if: steps.dispatch_failure.outputs.should_dispatch != 'true'
+        run: echo "Failure was not caused by a recoverable retry dispatch error; skipping fallback dispatch."

--- a/.github/workflows/auto_rerun_update_resume.yml
+++ b/.github/workflows/auto_rerun_update_resume.yml
@@ -34,19 +34,21 @@ jobs:
         run: |
           set -euo pipefail
 
-          failed_retry_dispatches="$(timeout 30s gh run view "${RUN_ID}" --repo "${GH_REPO}" --json jobs --jq '
-            [.jobs[]
-              | .steps[]?
+          retry_job_id="$(timeout 30s gh run view "${RUN_ID}" --repo "${GH_REPO}" --json jobs --jq '
+            [.jobs[] as $job
+              | $job.steps[]?
               | select(
                   (.name == "Notify JobKorea probe failure" or
                    .name == "Dispatch retry after update failure") and
                   .conclusion == "failure"
                 )
-            ] | length
+              | $job.databaseId
+            ] | .[0] // empty
           ')"
 
-          if [ "${failed_retry_dispatches}" -gt 0 ]; then
+          if [ -n "${retry_job_id}" ]; then
             echo "should_rerun=true" >> "${GITHUB_OUTPUT}"
+            echo "retry_job_id=${retry_job_id}" >> "${GITHUB_OUTPUT}"
           else
             echo "should_rerun=false" >> "${GITHUB_OUTPUT}"
           fi
@@ -60,6 +62,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          RETRY_JOB_ID: ${{ steps.dispatch-failure.outputs.retry_job_id }}
         run: |
           set -euo pipefail
 
@@ -83,7 +86,9 @@ jobs:
             sleep "${delay_seconds}"
           fi
 
-          timeout 30s gh run rerun "${RUN_ID}" --repo "${GH_REPO}" --failed
+          timeout 30s gh run rerun "${RUN_ID}" \
+            --repo "${GH_REPO}" \
+            --job "${RETRY_JOB_ID}"
 
       - name: Notify exhausted dispatch fallback
         if: >

--- a/.github/workflows/auto_rerun_update_resume.yml
+++ b/.github/workflows/auto_rerun_update_resume.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  rerun-on-probe-failure:
+  rerun-on-dispatch-failure:
     if: >
       (github.event.workflow_run.event == 'schedule' ||
       github.event.workflow_run.event == 'workflow_dispatch') &&
@@ -25,8 +25,8 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - name: Check probe failure
-        id: probe-failure
+      - name: Check retry dispatch failure
+        id: dispatch-failure
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -34,23 +34,26 @@ jobs:
         run: |
           set -euo pipefail
 
-          failed_probe_notifications="$(timeout 30s gh run view "${RUN_ID}" --repo "${GH_REPO}" --json jobs --jq '
+          failed_retry_dispatches="$(timeout 30s gh run view "${RUN_ID}" --repo "${GH_REPO}" --json jobs --jq '
             [.jobs[]
-              | select(.name == "update-resume-probe")
-              | .steps[]
-              | select(.name == "Notify JobKorea probe failure" and .conclusion == "failure")
+              | .steps[]?
+              | select(
+                  (.name == "Notify JobKorea probe failure" or
+                   .name == "Dispatch retry after update failure") and
+                  .conclusion == "failure"
+                )
             ] | length
           ')"
 
-          if [ "${failed_probe_notifications}" = "1" ]; then
+          if [ "${failed_retry_dispatches}" -gt 0 ]; then
             echo "should_rerun=true" >> "${GITHUB_OUTPUT}"
           else
             echo "should_rerun=false" >> "${GITHUB_OUTPUT}"
           fi
 
-      - name: Rerun failed update job
+      - name: Rerun failed retry dispatcher
         if: >
-          steps.probe-failure.outputs.should_rerun == 'true' &&
+          steps.dispatch-failure.outputs.should_rerun == 'true' &&
           github.event.workflow_run.run_attempt < 4
         env:
           GH_TOKEN: ${{ github.token }}
@@ -76,7 +79,7 @@ jobs:
           esac
 
           if [ "${delay_seconds}" -gt 0 ]; then
-            echo "Waiting ${delay_seconds}s before rerunning failed update job."
+            echo "Waiting ${delay_seconds}s before rerunning failed retry dispatcher."
             sleep "${delay_seconds}"
           fi
 
@@ -84,7 +87,7 @@ jobs:
 
       - name: Notify exhausted dispatch fallback
         if: >
-          steps.probe-failure.outputs.should_rerun == 'true' &&
+          steps.dispatch-failure.outputs.should_rerun == 'true' &&
           github.event.workflow_run.run_attempt >= 4
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
@@ -95,7 +98,7 @@ jobs:
 
           MESSAGE="$(cat <<EOF
           ❌ 이력서 업데이트 재시도 생성 실패
-          이유: JobKorea probe 실패 후 다음 workflow run을 생성하지 못했습니다.
+          이유: 실패 후 다음 workflow run을 생성하지 못했습니다.
           조치: 자동 보조 재실행도 모두 소진되었습니다.
           확인: ${RUN_URL}
           시간: $(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M:%S KST')
@@ -110,6 +113,6 @@ jobs:
             --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
             --data-urlencode "text=${MESSAGE}" || echo "Telegram fallback exhaustion notification failed"
 
-      - name: Skip non-probe failure
-        if: steps.probe-failure.outputs.should_rerun != 'true'
-        run: echo "Failure was not caused by the JobKorea probe; skipping auto rerun."
+      - name: Skip non-dispatch failure
+        if: steps.dispatch-failure.outputs.should_rerun != 'true'
+        run: echo "Failure was not caused by a retry dispatch error; skipping fallback rerun."

--- a/.github/workflows/auto_rerun_update_resume.yml
+++ b/.github/workflows/auto_rerun_update_resume.yml
@@ -79,7 +79,33 @@ jobs:
           sleep 180
 
           dispatch_retry() {
-            local dispatch_attempt dispatch_delay
+            local active_retry dispatch_attempt dispatch_delay
+
+            retry_already_active() {
+              if ! active_retry="$(
+                timeout 30s gh run list \
+                  --repo "${GH_REPO}" \
+                  --workflow update_resume.yml \
+                  --branch "${RETRY_REF}" \
+                  --event workflow_dispatch \
+                  --limit 20 \
+                  --json displayTitle,status \
+                  | jq --arg title "Update Resume (attempt ${NEXT_ATTEMPT})" \
+                    'any(.[]; .displayTitle == $title and .status != "completed")'
+              )"; then
+                echo "Unable to verify whether retry attempt ${NEXT_ATTEMPT} already exists. Refusing a duplicate dispatch."
+                return 2
+              fi
+              [ "${active_retry}" = "true" ]
+            }
+
+            if retry_already_active; then
+              echo "Retry attempt ${NEXT_ATTEMPT} is already queued or running."
+              return 0
+            elif [ "$?" -eq 2 ]; then
+              return 1
+            fi
+
             for dispatch_attempt in 1 2 3; do
               if timeout 30s gh workflow run update_resume.yml \
                 --repo "${GH_REPO}" \
@@ -88,10 +114,15 @@ jobs:
                 return 0
               fi
 
-              if [ "${dispatch_attempt}" -lt 3 ]; then
-                dispatch_delay=$((dispatch_attempt * 5))
-                echo "Fallback dispatch failed (${dispatch_attempt}/3). Retrying in ${dispatch_delay}s."
-                sleep "${dispatch_delay}"
+              dispatch_delay=$((dispatch_attempt * 5))
+              echo "Fallback dispatch returned an error (${dispatch_attempt}/3). Checking for an accepted run in ${dispatch_delay}s."
+              sleep "${dispatch_delay}"
+
+              if retry_already_active; then
+                echo "Retry attempt ${NEXT_ATTEMPT} was accepted despite the dispatch error."
+                return 0
+              elif [ "$?" -eq 2 ]; then
+                return 1
               fi
             done
             return 1

--- a/.github/workflows/update_resume.yml
+++ b/.github/workflows/update_resume.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   probe-job:
-    name: update-resume-probe
+    name: update-resume-probe-${{ github.event.inputs.attempt || '1' }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
@@ -237,7 +237,7 @@ jobs:
           exit "${exit_code}"
 
   retry-update-failure:
-    name: retry-update-resume
+    name: retry-update-resume-${{ github.event.inputs.attempt || '1' }}
     needs:
       - probe-job
       - update-resume

--- a/.github/workflows/update_resume.yml
+++ b/.github/workflows/update_resume.yml
@@ -110,10 +110,27 @@ jobs:
             delay_seconds=$((RETRY_DELAY_MINUTES * 60))
             echo "Waiting ${delay_seconds}s before dispatching retry attempt ${NEXT_ATTEMPT}/${MAX_ATTEMPTS}."
             sleep "${delay_seconds}"
-            timeout 30s gh workflow run update_resume.yml \
-              --repo "${GH_REPO}" \
-              --ref "${RETRY_REF}" \
-              -f "attempt=${NEXT_ATTEMPT}"
+
+            dispatch_retry() {
+              local dispatch_attempt dispatch_delay
+              for dispatch_attempt in 1 2 3; do
+                if timeout 30s gh workflow run update_resume.yml \
+                  --repo "${GH_REPO}" \
+                  --ref "${RETRY_REF}" \
+                  -f "attempt=${NEXT_ATTEMPT}"; then
+                  return 0
+                fi
+
+                if [ "${dispatch_attempt}" -lt 3 ]; then
+                  dispatch_delay=$((dispatch_attempt * 5))
+                  echo "Retry dispatch failed (${dispatch_attempt}/3). Retrying in ${dispatch_delay}s."
+                  sleep "${dispatch_delay}"
+                fi
+              done
+              return 1
+            }
+
+            dispatch_retry
             echo "retry-dispatched=true" >> "${GITHUB_OUTPUT}"
             exit 0
           else
@@ -155,6 +172,8 @@ jobs:
     # Ubuntu 22.04 permits Chromium's unprivileged user-namespace sandbox.
     runs-on: ubuntu-22.04
     timeout-minutes: 25
+    outputs:
+      update_step_outcome: ${{ steps.update_script.outcome }}
     permissions:
       contents: read
 
@@ -201,6 +220,7 @@ jobs:
         run: pnpm tsc
 
       - name: Run update script
+        id: update_script
         env:
           JOBKOREA_ID: ${{ secrets.JOBKOREA_ID }}
           JOBKOREA_PWD: ${{ secrets.JOBKOREA_PWD }}
@@ -209,6 +229,85 @@ jobs:
           NAVIGATION_TIMEOUT_MS: "30000"
         run: node dist/index.js
 
+  retry-update-failure:
+    name: retry-update-resume
+    needs:
+      - probe-job
+      - update-resume
+    if: >
+      always() &&
+      needs['probe-job'].result == 'success' &&
+      needs['update-resume'].result == 'failure' &&
+      needs['update-resume'].outputs.update_step_outcome == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+      - name: Dispatch retry after update failure
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RETRY_REF: ${{ github.ref_name }}
+          RUN_ATTEMPT: ${{ github.event.inputs.attempt || '1' }}
+        run: |
+          set -euo pipefail
+
+          MAX_ATTEMPTS=4
+          case "${RUN_ATTEMPT}" in
+            1|2|3|4)
+              ;;
+            *)
+              RUN_ATTEMPT=1
+              ;;
+          esac
+
+          if [ "${RUN_ATTEMPT}" -ge "${MAX_ATTEMPTS}" ]; then
+            echo "Update job failed on terminal retry attempt ${RUN_ATTEMPT}/${MAX_ATTEMPTS}."
+            exit 0
+          fi
+
+          NEXT_ATTEMPT=$((RUN_ATTEMPT + 1))
+          case "${RUN_ATTEMPT}" in
+            1)
+              RETRY_DELAY_MINUTES=3
+              ;;
+            2)
+              RETRY_DELAY_MINUTES=8
+              ;;
+            3)
+              RETRY_DELAY_MINUTES=15
+              ;;
+          esac
+
+          RETRY_REF="${RETRY_REF:-main}"
+          delay_seconds=$((RETRY_DELAY_MINUTES * 60))
+          echo "Waiting ${delay_seconds}s before dispatching retry attempt ${NEXT_ATTEMPT}/${MAX_ATTEMPTS} after update failure."
+          sleep "${delay_seconds}"
+
+          dispatch_retry() {
+            local dispatch_attempt dispatch_delay
+            for dispatch_attempt in 1 2 3; do
+              if timeout 30s gh workflow run update_resume.yml \
+                --repo "${GH_REPO}" \
+                --ref "${RETRY_REF}" \
+                -f "attempt=${NEXT_ATTEMPT}"; then
+                return 0
+              fi
+
+              if [ "${dispatch_attempt}" -lt 3 ]; then
+                dispatch_delay=$((dispatch_attempt * 5))
+                echo "Retry dispatch failed (${dispatch_attempt}/3). Retrying in ${dispatch_delay}s."
+                sleep "${dispatch_delay}"
+              fi
+            done
+            return 1
+          }
+
+          dispatch_retry
+
   workflow-keepalive:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
@@ -216,3 +315,4 @@ jobs:
       actions: write
     steps:
       - uses: liskin/gh-workflow-keepalive@v1
+        continue-on-error: true

--- a/.github/workflows/update_resume.yml
+++ b/.github/workflows/update_resume.yml
@@ -173,6 +173,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 25
     outputs:
+      update_exit_code: ${{ steps.update_script.outputs.exit_code }}
       update_step_outcome: ${{ steps.update_script.outcome }}
     permissions:
       contents: read
@@ -227,7 +228,13 @@ jobs:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           NAVIGATION_TIMEOUT_MS: "30000"
-        run: node dist/index.js
+        run: |
+          set +e
+          node dist/index.js
+          exit_code=$?
+          set -e
+          echo "exit_code=${exit_code}" >> "${GITHUB_OUTPUT}"
+          exit "${exit_code}"
 
   retry-update-failure:
     name: retry-update-resume
@@ -238,7 +245,8 @@ jobs:
       always() &&
       needs['probe-job'].result == 'success' &&
       needs['update-resume'].result == 'failure' &&
-      needs['update-resume'].outputs.update_step_outcome == 'failure'
+      needs['update-resume'].outputs.update_step_outcome == 'failure' &&
+      needs['update-resume'].outputs.update_exit_code == '75'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/update_resume.yml
+++ b/.github/workflows/update_resume.yml
@@ -1,5 +1,6 @@
 # .github/workflows/update_resume.yml
 name: Update Resume
+run-name: Update Resume (attempt ${{ github.event.inputs.attempt || '1' }})
 
 on:
   schedule:
@@ -112,7 +113,33 @@ jobs:
             sleep "${delay_seconds}"
 
             dispatch_retry() {
-              local dispatch_attempt dispatch_delay
+              local active_retry dispatch_attempt dispatch_delay
+
+              retry_already_active() {
+                if ! active_retry="$(
+                  timeout 30s gh run list \
+                    --repo "${GH_REPO}" \
+                    --workflow update_resume.yml \
+                    --branch "${RETRY_REF}" \
+                    --event workflow_dispatch \
+                    --limit 20 \
+                    --json displayTitle,status \
+                    | jq --arg title "Update Resume (attempt ${NEXT_ATTEMPT})" \
+                      'any(.[]; .displayTitle == $title and .status != "completed")'
+                )"; then
+                  echo "Unable to verify whether retry attempt ${NEXT_ATTEMPT} already exists. Refusing a duplicate dispatch."
+                  return 2
+                fi
+                [ "${active_retry}" = "true" ]
+              }
+
+              if retry_already_active; then
+                echo "Retry attempt ${NEXT_ATTEMPT} is already queued or running."
+                return 0
+              elif [ "$?" -eq 2 ]; then
+                return 1
+              fi
+
               for dispatch_attempt in 1 2 3; do
                 if timeout 30s gh workflow run update_resume.yml \
                   --repo "${GH_REPO}" \
@@ -121,10 +148,15 @@ jobs:
                   return 0
                 fi
 
-                if [ "${dispatch_attempt}" -lt 3 ]; then
-                  dispatch_delay=$((dispatch_attempt * 5))
-                  echo "Retry dispatch failed (${dispatch_attempt}/3). Retrying in ${dispatch_delay}s."
-                  sleep "${dispatch_delay}"
+                dispatch_delay=$((dispatch_attempt * 5))
+                echo "Retry dispatch returned an error (${dispatch_attempt}/3). Checking for an accepted run in ${dispatch_delay}s."
+                sleep "${dispatch_delay}"
+
+                if retry_already_active; then
+                  echo "Retry attempt ${NEXT_ATTEMPT} was accepted despite the dispatch error."
+                  return 0
+                elif [ "$?" -eq 2 ]; then
+                  return 1
                 fi
               done
               return 1
@@ -296,7 +328,33 @@ jobs:
           sleep "${delay_seconds}"
 
           dispatch_retry() {
-            local dispatch_attempt dispatch_delay
+            local active_retry dispatch_attempt dispatch_delay
+
+            retry_already_active() {
+              if ! active_retry="$(
+                timeout 30s gh run list \
+                  --repo "${GH_REPO}" \
+                  --workflow update_resume.yml \
+                  --branch "${RETRY_REF}" \
+                  --event workflow_dispatch \
+                  --limit 20 \
+                  --json displayTitle,status \
+                  | jq --arg title "Update Resume (attempt ${NEXT_ATTEMPT})" \
+                    'any(.[]; .displayTitle == $title and .status != "completed")'
+              )"; then
+                echo "Unable to verify whether retry attempt ${NEXT_ATTEMPT} already exists. Refusing a duplicate dispatch."
+                return 2
+              fi
+              [ "${active_retry}" = "true" ]
+            }
+
+            if retry_already_active; then
+              echo "Retry attempt ${NEXT_ATTEMPT} is already queued or running."
+              return 0
+            elif [ "$?" -eq 2 ]; then
+              return 1
+            fi
+
             for dispatch_attempt in 1 2 3; do
               if timeout 30s gh workflow run update_resume.yml \
                 --repo "${GH_REPO}" \
@@ -305,10 +363,15 @@ jobs:
                 return 0
               fi
 
-              if [ "${dispatch_attempt}" -lt 3 ]; then
-                dispatch_delay=$((dispatch_attempt * 5))
-                echo "Retry dispatch failed (${dispatch_attempt}/3). Retrying in ${dispatch_delay}s."
-                sleep "${dispatch_delay}"
+              dispatch_delay=$((dispatch_attempt * 5))
+              echo "Retry dispatch returned an error (${dispatch_attempt}/3). Checking for an accepted run in ${dispatch_delay}s."
+              sleep "${dispatch_delay}"
+
+              if retry_already_active; then
+                echo "Retry attempt ${NEXT_ATTEMPT} was accepted despite the dispatch error."
+                return 0
+              elif [ "$?" -eq 2 ]; then
+                return 1
               fi
             done
             return 1

--- a/.github/workflows/update_resume.yml
+++ b/.github/workflows/update_resume.yml
@@ -260,6 +260,7 @@ jobs:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           NAVIGATION_TIMEOUT_MS: "30000"
+          WORKFLOW_ATTEMPT: ${{ github.event.inputs.attempt || '1' }}
         run: |
           set +e
           node dist/index.js

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GitHub Actions cron은 매일 08:50, 12:50 KST 실행을 요청합니다. GitHub
 
 예약 실행에서는 checkout과 의존성 설치 전에 JobKorea 로그인 endpoint를 probe합니다. 연결 오류나 HTTP 4xx/5xx가 발생하거나 실제 이력서 업데이트 단계가 재시도 가능한 navigation 오류로 실패하면 새 workflow run을 생성합니다. 인증, 보안 경계, 업데이트 오류는 계정 잠금이나 중복 변경을 피하기 위해 workflow 단위로 재시도하지 않습니다. 정상 retry chain은 최초 시도를 포함해 총 4번까지 시도하며, 재시도 전에 순서대로 약 3분, 8분, 15분 대기합니다.
 
-다음 시도를 정상적으로 예약한 미완료 run은 성공으로 오인되지 않도록 실패로 표시됩니다. 이런 run의 최종 결과는 이어서 생성된 `workflow_dispatch` run에서 확인해야 합니다. 각 `workflow_dispatch` 호출은 일시적인 GitHub API 오류에 대비해 최대 3번까지 시도됩니다. 최상위 예약 실행이나 사용자가 시작한 `workflow_dispatch`에서 다음 run 생성 자체가 최종적으로 실패하면 `Auto Rerun Update Resume` workflow가 실패한 재시도 생성 job을 보조적으로 재실행합니다. 최종 4차 실패는 별도 단계로 표시해 보조 rerun 대상에서 제외합니다.
+다음 시도를 정상적으로 예약한 미완료 run은 성공으로 오인되지 않도록 실패로 표시됩니다. 이런 run의 최종 결과는 이어서 생성된 `workflow_dispatch` run에서 확인해야 합니다. 각 `workflow_dispatch` 호출은 일시적인 GitHub API 오류에 대비해 최대 3번까지 시도됩니다. 최상위 예약 실행이나 사용자가 시작한 `workflow_dispatch`에서 다음 run 생성 자체가 최종적으로 실패하면 `Auto Rerun Update Resume` workflow가 실패한 updater job을 재실행하지 않고 누락된 다음 `workflow_dispatch`를 직접 생성합니다. 최종 4차 실패는 별도 단계로 표시해 보조 dispatch 대상에서 제외합니다.
 
 Probe와 update retry job은 후속 workflow dispatch를 위해, 격리된 keepalive job은 예약 실행 유지를 위해 각각 `actions: write` 권한을 사용합니다. Keepalive는 best-effort 보조 작업이라 외부 GitHub API 장애가 전체 업데이트 결과를 실패로 바꾸지 않습니다. 자격증명이 주입되는 실제 이력서 업데이트 job은 `contents: read` 권한만 가지며, 인증 정보 제출은 계정 잠금을 막기 위해 한 번만 수행합니다. 브라우저의 모든 frame 이동은 HTTPS JobKorea 도메인으로 제한하고, 아이디·비밀번호·제출 버튼이 실제로 같은 POST 로그인 폼에 속하며 action과 target이 안전할 때만 자격증명을 입력합니다. 자격증명이 DOM에 있는 동안에는 JobKorea 외부 HTTP 요청을 차단하며 외부 WebSocket과 service worker도 사용하지 않습니다.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GitHub Actions cron은 매일 08:50, 12:50 KST 실행을 요청합니다. GitHub
 
 예약 실행에서는 checkout과 의존성 설치 전에 JobKorea 로그인 endpoint를 probe합니다. 연결 오류나 HTTP 4xx/5xx가 발생하거나 실제 이력서 업데이트 단계가 실패하면 새 workflow run을 생성합니다. 정상 retry chain은 최초 시도를 포함해 총 4번까지 시도하며, 재시도 전에 순서대로 약 3분, 8분, 15분 대기합니다.
 
-다음 시도를 정상적으로 예약한 미완료 run은 성공으로 오인되지 않도록 실패로 표시됩니다. 이런 run의 최종 결과는 이어서 생성된 `workflow_dispatch` run에서 확인해야 합니다. 각 workflow dispatch는 일시적인 GitHub API 오류에 대비해 최대 3번 요청합니다. 최상위 예약 실행이나 사용자가 시작한 `workflow_dispatch`에서 다음 run 생성 자체가 끝내 실패하면 `Auto Rerun Update Resume` workflow가 실패한 재시도 생성 job을 보조적으로 재실행합니다. 최종 4차 실패는 별도 단계로 표시해 보조 rerun 대상에서 제외합니다.
+다음 시도를 정상적으로 예약한 미완료 run은 성공으로 오인되지 않도록 실패로 표시됩니다. 이런 run의 최종 결과는 이어서 생성된 `workflow_dispatch` run에서 확인해야 합니다. 각 `workflow_dispatch` 호출은 일시적인 GitHub API 오류에 대비해 최대 3번까지 시도됩니다. 최상위 예약 실행이나 사용자가 시작한 `workflow_dispatch`에서 다음 run 생성 자체가 최종적으로 실패하면 `Auto Rerun Update Resume` workflow가 실패한 재시도 생성 job을 보조적으로 재실행합니다. 최종 4차 실패는 별도 단계로 표시해 보조 rerun 대상에서 제외합니다.
 
 Probe와 update retry job은 후속 workflow dispatch를 위해, 격리된 keepalive job은 예약 실행 유지를 위해 각각 `actions: write` 권한을 사용합니다. Keepalive는 best-effort 보조 작업이라 외부 GitHub API 장애가 전체 업데이트 결과를 실패로 바꾸지 않습니다. 자격증명이 주입되는 실제 이력서 업데이트 job은 `contents: read` 권한만 가지며, 인증 정보 제출은 계정 잠금을 막기 위해 한 번만 수행합니다. 브라우저의 모든 frame 이동은 HTTPS JobKorea 도메인으로 제한하고, 아이디·비밀번호·제출 버튼이 실제로 같은 POST 로그인 폼에 속하며 action과 target이 안전할 때만 자격증명을 입력합니다. 자격증명이 DOM에 있는 동안에는 JobKorea 외부 HTTP 요청을 차단하며 외부 WebSocket과 service worker도 사용하지 않습니다.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 GitHub Actions cron은 매일 08:50, 12:50 KST 실행을 요청합니다. GitHub의 scheduled workflow는 best-effort 방식이므로 실제 시작 시각은 runner 상황에 따라 늦어질 수 있습니다.
 
-예약 실행에서는 checkout과 의존성 설치 전에 JobKorea 로그인 endpoint를 probe합니다. 연결 오류나 HTTP 4xx/5xx가 발생하거나 실제 이력서 업데이트 단계가 재시도 가능한 navigation 오류로 실패하면 새 workflow run을 생성합니다. 인증, 보안 경계, 업데이트 오류는 계정 잠금이나 중복 변경을 피하기 위해 workflow 단위로 재시도하지 않습니다. 정상 retry chain은 최초 시도를 포함해 총 4번까지 시도하며, 재시도 전에 순서대로 약 3분, 8분, 15분 대기합니다.
+예약 실행에서는 checkout과 의존성 설치 전에 JobKorea 로그인 endpoint를 probe합니다. 연결 오류나 HTTP 4xx/5xx가 발생하거나 실제 이력서 업데이트 단계가 재시도 가능한 navigation 오류로 실패하면 새 workflow run을 생성합니다. 1~3차의 해당 실패는 Telegram에 일시 실패와 다음 시도 예정으로 알리고, 4차에서만 최종 실패로 알립니다. 인증, 보안 경계, 업데이트 오류는 계정 잠금이나 중복 변경을 피하기 위해 workflow 단위로 재시도하지 않습니다. 정상 retry chain은 최초 시도를 포함해 총 4번까지 시도하며, 재시도 전에 순서대로 약 3분, 8분, 15분 대기합니다.
 
 다음 시도를 정상적으로 예약한 미완료 run은 성공으로 오인되지 않도록 실패로 표시됩니다. 이런 run의 최종 결과는 이어서 생성된 `workflow_dispatch` run에서 확인해야 합니다. 각 `workflow_dispatch` 호출은 일시적인 GitHub API 오류에 대비해 최대 3번까지 시도하되, 다음 요청 전에 같은 attempt의 queued/in-progress run이 있는지 확인해 중복 생성을 막습니다. 확인 자체가 실패하면 중복 실행보다 안전한 중단을 선택합니다. 최상위 예약 실행이나 사용자가 시작한 `workflow_dispatch`에서 다음 run 생성 자체가 최종적으로 실패하면 `Auto Rerun Update Resume` workflow가 실패한 updater job을 재실행하지 않고 누락된 다음 `workflow_dispatch`를 직접 생성합니다. 최종 4차 실패는 별도 단계로 표시해 보조 dispatch 대상에서 제외합니다.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GitHub Actions cron은 매일 08:50, 12:50 KST 실행을 요청합니다. GitHub
 
 예약 실행에서는 checkout과 의존성 설치 전에 JobKorea 로그인 endpoint를 probe합니다. 연결 오류나 HTTP 4xx/5xx가 발생하거나 실제 이력서 업데이트 단계가 재시도 가능한 navigation 오류로 실패하면 새 workflow run을 생성합니다. 인증, 보안 경계, 업데이트 오류는 계정 잠금이나 중복 변경을 피하기 위해 workflow 단위로 재시도하지 않습니다. 정상 retry chain은 최초 시도를 포함해 총 4번까지 시도하며, 재시도 전에 순서대로 약 3분, 8분, 15분 대기합니다.
 
-다음 시도를 정상적으로 예약한 미완료 run은 성공으로 오인되지 않도록 실패로 표시됩니다. 이런 run의 최종 결과는 이어서 생성된 `workflow_dispatch` run에서 확인해야 합니다. 각 `workflow_dispatch` 호출은 일시적인 GitHub API 오류에 대비해 최대 3번까지 시도됩니다. 최상위 예약 실행이나 사용자가 시작한 `workflow_dispatch`에서 다음 run 생성 자체가 최종적으로 실패하면 `Auto Rerun Update Resume` workflow가 실패한 updater job을 재실행하지 않고 누락된 다음 `workflow_dispatch`를 직접 생성합니다. 최종 4차 실패는 별도 단계로 표시해 보조 dispatch 대상에서 제외합니다.
+다음 시도를 정상적으로 예약한 미완료 run은 성공으로 오인되지 않도록 실패로 표시됩니다. 이런 run의 최종 결과는 이어서 생성된 `workflow_dispatch` run에서 확인해야 합니다. 각 `workflow_dispatch` 호출은 일시적인 GitHub API 오류에 대비해 최대 3번까지 시도하되, 다음 요청 전에 같은 attempt의 queued/in-progress run이 있는지 확인해 중복 생성을 막습니다. 확인 자체가 실패하면 중복 실행보다 안전한 중단을 선택합니다. 최상위 예약 실행이나 사용자가 시작한 `workflow_dispatch`에서 다음 run 생성 자체가 최종적으로 실패하면 `Auto Rerun Update Resume` workflow가 실패한 updater job을 재실행하지 않고 누락된 다음 `workflow_dispatch`를 직접 생성합니다. 최종 4차 실패는 별도 단계로 표시해 보조 dispatch 대상에서 제외합니다.
 
 Probe와 update retry job은 후속 workflow dispatch를 위해, 격리된 keepalive job은 예약 실행 유지를 위해 각각 `actions: write` 권한을 사용합니다. Keepalive는 best-effort 보조 작업이라 외부 GitHub API 장애가 전체 업데이트 결과를 실패로 바꾸지 않습니다. 자격증명이 주입되는 실제 이력서 업데이트 job은 `contents: read` 권한만 가지며, 인증 정보 제출은 계정 잠금을 막기 위해 한 번만 수행합니다. 브라우저의 모든 frame 이동은 HTTPS JobKorea 도메인으로 제한하고, 아이디·비밀번호·제출 버튼이 실제로 같은 POST 로그인 폼에 속하며 action과 target이 안전할 때만 자격증명을 입력합니다. 자격증명이 DOM에 있는 동안에는 JobKorea 외부 HTTP 요청을 차단하며 외부 WebSocket과 service worker도 사용하지 않습니다.
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 GitHub Actions cron은 매일 08:50, 12:50 KST 실행을 요청합니다. GitHub의 scheduled workflow는 best-effort 방식이므로 실제 시작 시각은 runner 상황에 따라 늦어질 수 있습니다.
 
-예약 실행에서는 checkout과 의존성 설치 전에 JobKorea 로그인 endpoint를 probe합니다. 연결 오류나 HTTP 4xx/5xx가 발생하면 새 workflow run을 생성합니다. 정상 retry chain은 최초 시도를 포함해 총 4번까지 시도하며, 재시도 전에 순서대로 약 3분, 8분, 15분 대기합니다.
+예약 실행에서는 checkout과 의존성 설치 전에 JobKorea 로그인 endpoint를 probe합니다. 연결 오류나 HTTP 4xx/5xx가 발생하거나 실제 이력서 업데이트 단계가 실패하면 새 workflow run을 생성합니다. 정상 retry chain은 최초 시도를 포함해 총 4번까지 시도하며, 재시도 전에 순서대로 약 3분, 8분, 15분 대기합니다.
 
-다음 시도를 정상적으로 예약한 미완료 run은 성공으로 오인되지 않도록 실패로 표시됩니다. 이런 run의 최종 결과는 이어서 생성된 `workflow_dispatch` run에서 확인해야 합니다. 예약 실행이나 후속 `workflow_dispatch`에서 다음 run 생성 자체가 실패하면 `Auto Rerun Update Resume` workflow가 기존 failed probe job을 보조적으로 재실행합니다. 최종 4차 실패는 별도 단계로 표시해 보조 rerun 대상에서 제외합니다.
+다음 시도를 정상적으로 예약한 미완료 run은 성공으로 오인되지 않도록 실패로 표시됩니다. 이런 run의 최종 결과는 이어서 생성된 `workflow_dispatch` run에서 확인해야 합니다. 각 workflow dispatch는 일시적인 GitHub API 오류에 대비해 최대 3번 요청합니다. 최상위 예약 실행이나 사용자가 시작한 `workflow_dispatch`에서 다음 run 생성 자체가 끝내 실패하면 `Auto Rerun Update Resume` workflow가 실패한 재시도 생성 job을 보조적으로 재실행합니다. 최종 4차 실패는 별도 단계로 표시해 보조 rerun 대상에서 제외합니다.
 
-Probe job은 후속 workflow dispatch를 위해, 격리된 keepalive job은 예약 실행 유지를 위해 각각 `actions: write` 권한을 사용합니다. 자격증명이 주입되는 실제 이력서 업데이트 job은 `contents: read` 권한만 가지며, 인증 정보 제출은 계정 잠금을 막기 위해 한 번만 수행합니다. 브라우저의 모든 frame 이동은 HTTPS JobKorea 도메인으로 제한하고, 아이디·비밀번호·제출 버튼이 실제로 같은 POST 로그인 폼에 속하며 action과 target이 안전할 때만 자격증명을 입력합니다. 자격증명이 DOM에 있는 동안에는 JobKorea 외부 HTTP 요청을 차단하며 외부 WebSocket과 service worker도 사용하지 않습니다.
+Probe와 update retry job은 후속 workflow dispatch를 위해, 격리된 keepalive job은 예약 실행 유지를 위해 각각 `actions: write` 권한을 사용합니다. Keepalive는 best-effort 보조 작업이라 외부 GitHub API 장애가 전체 업데이트 결과를 실패로 바꾸지 않습니다. 자격증명이 주입되는 실제 이력서 업데이트 job은 `contents: read` 권한만 가지며, 인증 정보 제출은 계정 잠금을 막기 위해 한 번만 수행합니다. 브라우저의 모든 frame 이동은 HTTPS JobKorea 도메인으로 제한하고, 아이디·비밀번호·제출 버튼이 실제로 같은 POST 로그인 폼에 속하며 action과 target이 안전할 때만 자격증명을 입력합니다. 자격증명이 DOM에 있는 동안에는 JobKorea 외부 HTTP 요청을 차단하며 외부 WebSocket과 service worker도 사용하지 않습니다.
 
 Chromium은 sandbox를 명시적으로 활성화합니다. 브라우저를 실행하는 Actions job은 Chromium의 unprivileged user-namespace sandbox와 호환되는 `ubuntu-22.04`에 고정하며, CI가 실제 sandbox launch를 smoke test합니다.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 GitHub Actions cron은 매일 08:50, 12:50 KST 실행을 요청합니다. GitHub의 scheduled workflow는 best-effort 방식이므로 실제 시작 시각은 runner 상황에 따라 늦어질 수 있습니다.
 
-예약 실행에서는 checkout과 의존성 설치 전에 JobKorea 로그인 endpoint를 probe합니다. 연결 오류나 HTTP 4xx/5xx가 발생하거나 실제 이력서 업데이트 단계가 실패하면 새 workflow run을 생성합니다. 정상 retry chain은 최초 시도를 포함해 총 4번까지 시도하며, 재시도 전에 순서대로 약 3분, 8분, 15분 대기합니다.
+예약 실행에서는 checkout과 의존성 설치 전에 JobKorea 로그인 endpoint를 probe합니다. 연결 오류나 HTTP 4xx/5xx가 발생하거나 실제 이력서 업데이트 단계가 재시도 가능한 navigation 오류로 실패하면 새 workflow run을 생성합니다. 인증, 보안 경계, 업데이트 오류는 계정 잠금이나 중복 변경을 피하기 위해 workflow 단위로 재시도하지 않습니다. 정상 retry chain은 최초 시도를 포함해 총 4번까지 시도하며, 재시도 전에 순서대로 약 3분, 8분, 15분 대기합니다.
 
 다음 시도를 정상적으로 예약한 미완료 run은 성공으로 오인되지 않도록 실패로 표시됩니다. 이런 run의 최종 결과는 이어서 생성된 `workflow_dispatch` run에서 확인해야 합니다. 각 `workflow_dispatch` 호출은 일시적인 GitHub API 오류에 대비해 최대 3번까지 시도됩니다. 최상위 예약 실행이나 사용자가 시작한 `workflow_dispatch`에서 다음 run 생성 자체가 최종적으로 실패하면 `Auto Rerun Update Resume` workflow가 실패한 재시도 생성 job을 보조적으로 재실행합니다. 최종 4차 실패는 별도 단계로 표시해 보조 rerun 대상에서 제외합니다.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ const { updateResume }: typeof import("./updateResume") = require("./updateResum
 const { ConfigValidator }: typeof import("./utils/validation") = require("./utils/validation");
 const { Logger }: typeof import("./utils/logger") = require("./utils/logger");
 const { configManager }: typeof import("./config") = require("./config");
+const { getFailureExitCode }: typeof import("./types") = require("./types");
 
 function cleanupOldDiagnostics(): void {
   try {
@@ -96,7 +97,7 @@ async function main() {
     Logger.success("애플리케이션 정상 종료");
   } catch (error) {
     Logger.error("애플리케이션 실행 중 치명적 오류 발생", error as Error);
-    process.exitCode = 1;
+    process.exitCode = getFailureExitCode(error);
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,17 @@ export class UpdateError extends JobKoreaError {
   }
 }
 
+// EX_TEMPFAIL: the workflow may start a fresh runner only for a navigation
+// failure that is explicitly safe to retry. Authentication and update errors
+// keep the ordinary failure code so credentials or mutations are not repeated.
+export const RETRYABLE_NAVIGATION_EXIT_CODE = 75;
+
+export function getFailureExitCode(error: unknown): number {
+  return error instanceof NavigationError && error.retryable
+    ? RETRYABLE_NAVIGATION_EXIT_CODE
+    : 1;
+}
+
 export function isRetryableJobKoreaError(error: Error): boolean {
   return !(error instanceof JobKoreaError) || error.retryable;
 }

--- a/src/updateResume.ts
+++ b/src/updateResume.ts
@@ -1,5 +1,10 @@
 // src/updateResume.ts
-import { Config, isRetryableJobKoreaError, JobKoreaError } from "./types";
+import {
+  Config,
+  isRetryableJobKoreaError,
+  JobKoreaError,
+  NavigationError,
+} from "./types";
 import { Logger } from "./utils/logger";
 import { BrowserService } from "./services/browser";
 import { JobKoreaService } from "./services/jobkorea";
@@ -143,6 +148,26 @@ async function handleError(
   chatId: string,
   retryCount: number
 ): Promise<void> {
+  const errorMessage = formatFailureNotification(
+    error,
+    retryCount,
+    process.env.WORKFLOW_ATTEMPT
+  );
+
+  Logger.error("최종 에러 발생", error instanceof Error ? error : undefined);
+  await sendTelegramMessage(token, chatId, errorMessage);
+  Logger.info("실패 메시지 전송 완료");
+}
+
+export function formatFailureNotification(
+  error: unknown,
+  retryCount: number,
+  workflowAttemptValue?: string
+): string {
+  const maxWorkflowAttempts = 4;
+  const workflowAttempt = /^[1-4]$/.test(workflowAttemptValue ?? "")
+    ? Number(workflowAttemptValue)
+    : undefined;
   const retryInfo =
     retryCount > 1
       ? `\n재시도 횟수: ${retryCount - 1}번 (모든 재시도 실패)`
@@ -154,12 +179,19 @@ async function handleError(
         ? error.message
         : "알 수 없는 오류";
   const safeMessage = sanitizeNotificationErrorDetail(rawMessage);
-  const errorMessage =
+  const retryableWorkflowFailure =
+    error instanceof NavigationError &&
+    error.retryable &&
+    workflowAttempt !== undefined &&
+    workflowAttempt < maxWorkflowAttempts;
+
+  if (retryableWorkflowFailure) {
+    return `⚠️ 이력서 업데이트 일시 실패\n이유: ${safeMessage} (${error.code})${retryInfo}\n조치: workflow ${workflowAttempt + 1}/${maxWorkflowAttempts}번째 시도를 자동 생성할 예정입니다.`;
+  }
+
+  return (
     error instanceof JobKoreaError
       ? `❌ 이력서 업데이트 최종 실패!\n이유: ${safeMessage} (${error.code})${retryInfo}`
-      : `❌ 이력서 업데이트 최종 실패!\n이유: ${safeMessage}${retryInfo}`;
-
-  Logger.error("최종 에러 발생", error instanceof Error ? error : undefined);
-  await sendTelegramMessage(token, chatId, errorMessage);
-  Logger.info("실패 메시지 전송 완료");
+      : `❌ 이력서 업데이트 최종 실패!\n이유: ${safeMessage}${retryInfo}`
+  );
 }

--- a/test/retry.test.js
+++ b/test/retry.test.js
@@ -11,8 +11,10 @@ const {
 } = require("../src/utils/retry");
 const {
   AuthenticationError,
+  getFailureExitCode,
   isRetryableJobKoreaError,
   NavigationError,
+  RETRYABLE_NAVIGATION_EXIT_CODE,
 } = require("../src/types");
 
 test("caps server-requested retry delays at the configured maximum", () => {
@@ -84,6 +86,21 @@ test("authentication errors are permanent while navigation errors remain retryab
     false
   );
   assert.equal(isRetryableJobKoreaError(new Error("generic")), true);
+});
+
+test("workflow retry exit code is limited to safe navigation failures", () => {
+  assert.equal(
+    getFailureExitCode(new NavigationError("temporary")),
+    RETRYABLE_NAVIGATION_EXIT_CODE
+  );
+  assert.equal(
+    getFailureExitCode(
+      new NavigationError("security boundary", undefined, false)
+    ),
+    1
+  );
+  assert.equal(getFailureExitCode(new AuthenticationError("rejected")), 1);
+  assert.equal(getFailureExitCode(new Error("unexpected")), 1);
 });
 
 test("withRetry stops when the overall retry budget is exhausted", async () => {

--- a/test/update-message.test.js
+++ b/test/update-message.test.js
@@ -4,8 +4,10 @@ const assert = require("node:assert/strict");
 require("ts-node/register");
 
 const { configManager } = require("../src/config");
+const { AuthenticationError, NavigationError } = require("../src/types");
 const { Logger } = require("../src/utils/logger");
 const {
+  formatFailureNotification,
   sanitizeNotificationErrorDetail,
 } = require("../src/updateResume");
 
@@ -35,4 +37,30 @@ test("notification errors redact secrets and stay below Telegram's limit", () =>
   assert.doesNotMatch(detail, /notification-password|token=abc|evil\.example\/notification/);
   assert.match(detail, /\[생략됨\]$/);
   assert.doesNotMatch(detail, /<(?!\/)|&(?!amp;|lt;|gt;)/);
+});
+
+test("retryable workflow navigation failures use temporary notifications", () => {
+  const temporaryMessage = formatFailureNotification(
+    new NavigationError("temporary navigation"),
+    3,
+    "2"
+  );
+  assert.match(temporaryMessage, /일시 실패/);
+  assert.match(temporaryMessage, /workflow 3\/4번째 시도/);
+  assert.doesNotMatch(temporaryMessage, /최종 실패/);
+
+  const terminalMessage = formatFailureNotification(
+    new NavigationError("temporary navigation"),
+    3,
+    "4"
+  );
+  assert.match(terminalMessage, /최종 실패/);
+
+  const authenticationMessage = formatFailureNotification(
+    new AuthenticationError("rejected"),
+    1,
+    "1"
+  );
+  assert.match(authenticationMessage, /최종 실패/);
+  assert.doesNotMatch(authenticationMessage, /일시 실패/);
 });


### PR DESCRIPTION
## What changed

- dispatch a follow-up workflow only for explicitly retryable navigation failures, using the existing 1-4 attempt backoff chain
- preserve non-retryable authentication and mutation failures so credentials or side effects are not repeated
- retry transient GitHub API failures while creating the follow-up run
- make the fallback workflow detect retry-dispatch failures instead of misclassifying probe failures
- report retryable navigation failures as temporary until the final workflow attempt
- keep the best-effort keepalive action from marking a successful resume update as failed
- document the updated retry behavior

## Root cause

The probe could recover and allow the Playwright job to start, but a later navigation failure had no path to create the next workflow attempt. Runs created with the workflow token also do not produce the downstream `workflow_run` chain that the fallback workflow relied on.

## Validation

- workflow YAML parse
- embedded shell syntax check
- `pnpm lint`
- `pnpm test` (40 passed)
- `pnpm build`
- `pnpm test:browser`
- `git diff --check`
